### PR TITLE
Completed and fixed spanish translation

### DIFF
--- a/src/chrome/locale/es-ES/amcontextmenu.dtd
+++ b/src/chrome/locale/es-ES/amcontextmenu.dtd
@@ -1,16 +1,16 @@
 <!ENTITY AMcontext.inspectAddon "Inspeccionar complemento">
-<!ENTITY AMcontext.inspectUserscript "Inspeccionar Script de usuario">
-<!ENTITY AMcontext.browseDir "Elegir carpeta de instalación">
-<!ENTITY AMcontext.copyPersonasData     "Copy Theme Data">
-<!ENTITY AMcontext.copyName "Copiar nombre de complemento">
-<!ENTITY AMcontext.copyVersion "Copiar versión de complemento">
+<!ENTITY AMcontext.inspectUserscript "Inspeccionar script de usuario">
+<!ENTITY AMcontext.browseDir "Examinar carpeta de instalación">
+<!ENTITY AMcontext.copyPersonasData "Copiar datos del tema decorativo">
+<!ENTITY AMcontext.copyName "Copiar nombre del complemento">
+<!ENTITY AMcontext.copyVersion "Copiar versión del complemento">
 <!ENTITY AMcontext.copyNameVersion "Copiar nombre y versión del complemento">
-<!ENTITY AMcontext.copyId "Copiar ID de complemento">
-<!ENTITY AMcontext.copyHomePageURL "Copiar la dirección de la web">
+<!ENTITY AMcontext.copyId "Copiar identificador (ID) del complemento">
+<!ENTITY AMcontext.copyHomePageURL "Copiar dirección de la página del complemento">
 <!ENTITY AMcontext.releaseNotes "Notas de la versión">
-<!ENTITY AMcontext.visitHomePage "Visitar página web">
-<!ENTITY AMcontext.visitAMOPage "Visitar web de complementos de mozilla">
-<!ENTITY AMcontext.visitUSOPage "Ver en Userscripts.org">
-<!ENTITY AMcontext.findOnUSO "Buscar en Userscripts.org">
-<!ENTITY AMcontext.visitSupport "Visitar el soporte del complemento">
-<!ENTITY AMcontext.reviews "Revisiones del complemento">
+<!ENTITY AMcontext.visitHomePage "Visitar página del complemento">
+<!ENTITY AMcontext.visitAMOPage "Ver en la página de complementos de Mozilla">
+<!ENTITY AMcontext.visitUSOPage "Ver en userscripts.org">
+<!ENTITY AMcontext.findOnUSO "Buscar en userscripts.org">
+<!ENTITY AMcontext.visitSupport "Visitar el sitio de soporte del complemento">
+<!ENTITY AMcontext.reviews "Valoraciones del complemento">

--- a/src/chrome/locale/es-ES/amcontextmenu.properties
+++ b/src/chrome/locale/es-ES/amcontextmenu.properties
@@ -1,2 +1,2 @@
-extensions.amcontextmenu@loucypher.name=Menú contextual del administrador de complementos
-extensions.amcontextmenu@loucypher.description=Agregar entradas al menú contextual del administrador de complementos
+extensions.amcontextmenu@loucypher.name=Add-ons Manager Context Menu
+extensions.amcontextmenu@loucypher.description=Agrega más entradas al menú contextual del administrador de complementos

--- a/src/install.rdf
+++ b/src/install.rdf
@@ -19,7 +19,7 @@
         <em:description>Add more items to Add-ons Manager context menu.</em:description>
         <em:creator>LouCypher</em:creator>
         <em:homepageURL>http://loucypher.github.com/AM_contextmenu/</em:homepageURL>
-        <em:translator>Scooter - Español (de España)</em:translator>
+        <em:translator>Scooter, strel - Español (de España)</em:translator>
         <em:translator>Eva - Français</em:translator>
         <em:translator>JNF:) - עברית</em:translator>
         <em:translator>Hrant Ohanyan - Հայերեն</em:translator>
@@ -33,11 +33,11 @@
     <em:localized>
       <Description>
         <em:locale>es-ES</em:locale>
-        <em:name>Menú contextual del administrador de complementos</em:name>
-        <em:description>Agregar entradas al menú contextual del administrador de complementos</em:description>
+        <em:name>Add-ons Manager Context Menu</em:name>
+        <em:description>Agrega más entradas al menú contextual del administrador de complementos</em:description>
         <em:creator>LouCypher</em:creator>
         <em:homepageURL>http://loucypher.github.com/AM_contextmenu/</em:homepageURL>
-        <em:translator>Scooter</em:translator>
+        <em:translator>Scooter, strel</em:translator>
       </Description>
     </em:localized>
 


### PR DESCRIPTION
This completes spanish translation and fixes some problems in the previous one. Also I opted for not translating the name of the addon, as usually with spanish locales on other addons, and also because the name of the addon is in fact in english and that's how should be searched in the Internet in case you want to find comments about it from other users around the world, or even if you want to find it searching from the AMO search engine.

Note userstyles.org does not exists now, and that requires a solution.

By the way this a great extension so much needed. Thx for sharing it.
